### PR TITLE
Add fix for jumpy slider arrows - was caused by outside sass setting …

### DIFF
--- a/blocks/slider/slider.scss
+++ b/blocks/slider/slider.scss
@@ -50,6 +50,11 @@
 
 .braftonium-slider {
 
+    .slick-next, 
+    .slick-prev {
+        top: 50%;
+    }
+
     &.slick-dots-top {
         .slick-dots {
             top: -50px;


### PR DESCRIPTION
…button:active's top to 1px.